### PR TITLE
-l options should be added to LIBADD, not LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,11 +54,11 @@ PGUTexture.h \
 TexDB.h
 
 # We substitute the libtool-specific library version in configure.in.
-libglide2x_la_LDFLAGS = -no-undefined -version-info $(LIBVERSION) $(X_PRE_LIBS) $(X_LIBS) $(X_EXTRA_LIBS) $(DLLFLAGS)
+libglide2x_la_LDFLAGS = -no-undefined -version-info $(LIBVERSION) $(DLLFLAGS)
 
 INCLUDES=
 
-libglide2x_la_LIBADD = ./platform/linux/libplatform.la ./platform/sdl/libsdl.la ./platform/windows/libwindows.la
+libglide2x_la_LIBADD = ./platform/linux/libplatform.la ./platform/sdl/libsdl.la ./platform/windows/libwindows.la $(X_PRE_LIBS) $(X_LIBS) $(X_EXTRA_LIBS)
 
 install-data-hook:
 	cd $(DESTDIR)$(includedir) && \


### PR DESCRIPTION
Otherwise the flags are put in the wrong order with sometimes detrimental effects.
