### PR TITLE
Default to smooth shading as Tomb Raider sometimes switches to flat

### DIFF
--- a/Glide.cpp
+++ b/Glide.cpp
@@ -116,6 +116,8 @@ bool InitWindow( FxU hWnd )
 //*************************************************
 void InitOpenGL( void )
 {
+    glShadeModel( GL_SMOOTH );
+
     OpenGL.ZNear = ZBUFFERNEAR;
     OpenGL.ZFar = ZBUFFERFAR;
 


### PR DESCRIPTION
See http://www.vogons.org/viewtopic.php?p=226681#p226681.

Note this only seems to happen when using SDL, not X11.
