### PR TITLE
fix grTexDownloadMipMapLevelPartial

### DIFF
--- a/PGTexture.cpp
+++ b/PGTexture.cpp
@@ -177,6 +177,32 @@ void PGTexture::DownloadMipMap( FxU32 startAddress, FxU32 evenOdd, GrTexInfo *in
 #endif
 }
 
+void PGTexture::DownloadMipMapPartial( FxU32 startAddress, FxU32 evenOdd, GrTexInfo *info, int start, int end )
+{
+    // Glidos has different handling of grTexDownload, so keep it
+    if ( info->format == GR_TEXFMT_BGRA_8888 )
+    {
+        DownloadMipMap( startAddress, evenOdd, info );
+        return;
+    }
+
+    FxU32 mip_size = MipMapMemRequired( info->smallLod, 
+                                        info->aspectRatio, 
+                                        info->format );
+    FxU32 mip_offset = startAddress + TextureMemRequired( evenOdd, info );
+ 
+    if ( mip_offset <= m_tex_memory_size )
+    {
+        int stride = texInfo[ info->aspectRatio ][ info->smallLod ].width;
+        if (info->format >= GR_TEXFMT_16BIT)
+            stride *= 2;
+        FxU8 *mip_memory = m_memory + mip_offset - mip_size;
+        memcpy( mip_memory + start * stride, info->data, (end - start + 1) * stride );
+
+        m_db->WipeRange( startAddress, mip_offset, 0 );
+    }
+}
+
 void PGTexture::Source( FxU32 startAddress, FxU32 evenOdd, GrTexInfo *info )
 {
     m_startAddress = startAddress;

--- a/PGTexture.h
+++ b/PGTexture.h
@@ -41,6 +41,7 @@ public:
     void DownloadTable( GrTexTable_t type, FxU32 *data, int first, int count );
     void Source( FxU32 startAddress, FxU32 evenOdd, GrTexInfo *info );
     void DownloadMipMap( FxU32 startAddress, FxU32 evenOdd, GrTexInfo *info );
+    void DownloadMipMapPartial( FxU32 startAddress, FxU32 evenOdd, GrTexInfo *info, int start, int end );
     FxU32 GetMemorySize( void );
 
     PGTexture( int mem_size );

--- a/grguTex.cpp
+++ b/grguTex.cpp
@@ -165,8 +165,14 @@ grTexDownloadMipMapLevelPartial( GrChipID_t        tmu,
         return;
     }
 
-    grTexDownloadMipMapLevel( tmu, startAddress, thisLod, largeLod, aspectRatio, format,
-        evenOdd, data );
+    GrTexInfo info;
+    info.smallLod    = thisLod;
+    info.largeLod    = largeLod;
+    info.aspectRatio = aspectRatio;
+    info.format      = format;
+    info.data        = data;
+
+    Textures->DownloadMipMapPartial( startAddress, evenOdd, &info, start, end );
 }
 
 //*************************************************


### PR DESCRIPTION
Fixes invalid grTexDownloadMipMapLevelPartial behavior - it should only read and replace data of the size specified by start-end rows. Previously the start-end range was ignored and data block of the size of the given mip level was copied to internal memory. This works only if start is 0, the data block is large enough and the rest of the texture data is unchanged. Otherwise it causes texture corruption or crashes due to invalid reads.

I don't know if Glidos uses this function or not. If it does, it would need a different fix, but my guess is that it doesn't - somebody would likely already notice that it's broken.