### PR TITLE
Don't use wildcard when creating libglide.so.2 symlink

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,4 +64,4 @@ install-data-hook:
 
 install-exec-hook:
 	cd $(DESTDIR)$(libdir) && \
-		$(LN_S) -f lib*.so libglide.so.2
+		$(LN_S) -f libglide2x.so libglide.so.2


### PR DESCRIPTION
This doesn't work when there are other libraries in the same directory! We didn't spot this under Gentoo because it installs to a staging directory first.

@voyageur, I see that it was you who added the wildcard in the first place. I don't suppose you can remember why?