### PR TITLE
Add support for out-of-tree builds on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ case "$host" in
     *cygwin* | *mingw32*) 
         CXXFLAGS="$CXXFLAGS -DWIN32 -I\$(top_srcdir)/platform/windows"
         LIBS="$LIBS -luser32 -lgdi32 -lopengl32 -lglu32"
-        DLLFLAGS="-avoid-version -Wc,-def -Wc,Glide2x.def"
+        DLLFLAGS="-avoid-version -Wc,-def -Wc,$srcdir/Glide2x.def"
         ;;
     *darwin*)
         osflag="__linux__"


### PR DESCRIPTION
Linking `.libs/libglide2x.dll` requires `Glide2x.def`, but the linker should
look it into the root directory (`$srcdir`) instead of in the current
directory.