### PR TITLE
Add missing max() #define on Windows

### DIFF
--- a/platform/windows/platform.h
+++ b/platform/windows/platform.h
@@ -17,6 +17,8 @@
 #include <windows.h>
 #include <io.h>
 
+#define max(x,y) ((x) < (y) ? (y) : (x))
+
 #define FASTCALL __fastcall
 #define OG_memcpy MMXCopyMemory
 


### PR DESCRIPTION
It doesn’t build otherwise.