### PR TITLE
build: add missing x11 and xxf86vm libs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,7 +54,8 @@ TexDB.h
 # We substitute the libtool-specific library version in configure.in.
 libglide2x_la_LDFLAGS = -no-undefined -version-info $(LIBVERSION) $(DLLFLAGS)
 
-libglide2x_la_LIBADD = ./platform/linux/libplatform.la ./platform/sdl/libsdl.la ./platform/windows/libwindows.la
+libglide2x_la_LIBADD = ./platform/linux/libplatform.la ./platform/sdl/libsdl.la ./platform/windows/libwindows.la $(X11_LIBS) $(XF86VM_LIBS)
+libglide2x_la_CFLAGS = $(X11_CFLAGS) $(XF86VM_CFLAGS)
 
 install-data-hook:
 	cd $(DESTDIR)$(includedir) && \

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,13 @@ if test x$have_sdl_lib = xyes ; then
     # Don't need SDLmain since we're a library
     LIBS="$LIBS ${SDL_LIBS/-lSDLmain/}"
     CPPFLAGS="$CPPFLAGS $SDL_CFLAGS -I/usr/include"
+else
+    PKG_CHECK_MODULES([X11], [x11])
+    PKG_CHECK_MODULES([XF86VM], [xxf86vm])
+    AC_SUBST([X11_CFLAGS])
+    AC_SUBST([X11_LIBS])
+    AC_SUBST([XF86VM_CFLAGS])
+    AC_SUBST([XF86VM_LIBS])
 fi
 
 dnl The target cpu checks


### PR DESCRIPTION
When building with --disable-sdl and using slibtool it fails with many undefined references for x11 and xxf86vm symbols.

This is because the build doesn't link with either and uses -no-undefined. GNU libtool doesn't reproduce this issue because they silently ignore -no-undefined and omit it from the compiler command.

Gentoo Issue: https://bugs.gentoo.org/916581

-------------
```
rdlibtool --tag=CXX --mode=link g++ -g -O2 -D__unix__ -D__linux__ -I./platform/linux -no-undefined -version-info 0:0:0 -o libglide2x.la -rpath /usr/local/lib grguDepth.lo grguMisc.lo grgu3df.lo grguDraw.lo grguSstGlide.lo grguFog.lo grguTex.lo grguLfb.lo GLRender.lo OGLFogTables.lo OGLTextureTables.lo OGLColorAlphaTables.lo TexDB.lo PGUTexture.lo Glide.lo GLExtensions.lo PGTexture.lo FormatConversion.lo grguBuffer.lo grguColorAlpha.lo GLutil.lo gsplash.lo ./platform/linux/libplatform.la ./platform/sdl/libsdl.la ./platform/windows/libwindows.la -lGL -lGLU

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/openglide"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 30, .st_ino = 1730}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = 3.
rdlibtool: lconf: found "/tmp/openglide/libtool".
rdlibtool: link: ln -s libglide2x.so.def .libs/libglide2x.so.def.linux
rdlibtool: link: ln -s libglide2x.so.def.linux .libs/libglide2x.so.def.host
rdlibtool: link: x86_64-pc-linux-gnu-ar crs .libs/libglide2x.a .libs/grguDepth.o .libs/grguMisc.o .libs/grgu3df.o .libs/grguDraw.o .libs/grguSstGlide.o .libs/grguFog.o .libs/grguTex.o .libs/grguLfb.o .libs/GLRender.o .libs/OGLFogTables.o .libs/OGLTextureTables.o .libs/OGLColorAlphaTables.o .libs/TexDB.o .libs/PGUTexture.o .libs/Glide.o .libs/GLExtensions.o .libs/PGTexture.o .libs/FormatConversion.o .libs/grguBuffer.o .libs/grguColorAlpha.o .libs/GLutil.o .libs/gsplash.o
rdlibtool: link: g++ .libs/grguDepth.o .libs/grguMisc.o .libs/grgu3df.o .libs/grguDraw.o .libs/grguSstGlide.o .libs/grguFog.o .libs/grguTex.o .libs/grguLfb.o .libs/GLRender.o .libs/OGLFogTables.o .libs/OGLTextureTables.o .libs/OGLColorAlphaTables.o .libs/TexDB.o .libs/PGUTexture.o .libs/Glide.o .libs/GLExtensions.o .libs/PGTexture.o .libs/FormatConversion.o .libs/grguBuffer.o .libs/grguColorAlpha.o .libs/GLutil.o .libs/gsplash.o -Wl,--whole-archive ./platform/linux/.libs/libplatform.a -Wl,--no-whole-archive -Wl,--whole-archive ./platform/sdl/.libs/libsdl.a -Wl,--no-whole-archive -Wl,--whole-archive ./platform/windows/.libs/libwindows.a -Wl,--no-whole-archive -g -O2 -D__unix__ -D__linux__ -I./platform/linux -lGL -lGLU -lGL -shared -fPIC -Wl,--no-undefined -Wl,-soname -Wl,libglide2x.so.0 -o .libs/libglide2x.so.0.0.0
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `SetGamma(float)':
/tmp/openglide/platform/linux/window.cpp:283:(.text+0x20e): undefined reference to `XStoreColors'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `SetScreenMode(int&, int&)':
/tmp/openglide/platform/linux/window.cpp:307:(.text+0x2d8): undefined reference to `XF86VidModeGetAllModeLines'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:339:(.text+0x355): undefined reference to `XFree'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:331:(.text+0x3a2): undefined reference to `XF86VidModeSwitchToMode'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:333:(.text+0x3b8): undefined reference to `XF86VidModeSetViewPort'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `ResetScreenMode()':
/tmp/openglide/platform/linux/window.cpp:350:(.text+0x424): undefined reference to `XF86VidModeSwitchToMode'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:353:(.text+0x435): undefined reference to `XFree'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `FinaliseOpenGLWindow()':
/tmp/openglide/platform/linux/window.cpp:232:(.text+0x4b4): undefined reference to `XCloseDisplay'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:230:(.text+0x518): undefined reference to `XDestroyWindow'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `InitialiseOpenGLWindow(unsigned long, int, int, int, int)':
/tmp/openglide/platform/linux/window.cpp:62:(.text+0x720): undefined reference to `XOpenDisplay'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:133:(.text+0x882): undefined reference to `XF86VidModeQueryVersion'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:146:(.text+0x8b0): undefined reference to `XF86VidModeGetGammaRampSize'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:165:(.text+0x8e9): undefined reference to `XCreateColormap'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:185:(.text+0x97c): undefined reference to `XCreateWindow'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:188:(.text+0x996): undefined reference to `XMapWindow'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:200:(.text+0x9af): undefined reference to `XFlush'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:192:(.text+0xb33): undefined reference to `XMoveWindow'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:193:(.text+0xb46): undefined reference to `XRaiseWindow'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:194:(.text+0xb6d): undefined reference to `XWarpPointer'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:195:(.text+0xb7d): undefined reference to `XFlush'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:197:(.text+0xb93): undefined reference to `XF86VidModeSetViewPort'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:162:(.text+0xba9): undefined reference to `XCreateColormap'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:153:(.text+0xc24): undefined reference to `XF86VidModeGetGammaRamp'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `SetGamma(float)':
/tmp/openglide/platform/linux/window.cpp:265:(.text+0x12b): undefined reference to `XF86VidModeSetGammaRamp'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/openglide/platform/linux/window.cpp:284:(.text+0x22a): undefined reference to `XSync'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ./platform/linux/.libs/libplatform.a(window.o): in function `RestoreGamma()':
/tmp/openglide/platform/linux/window.cpp:296:(.text+0x28d): undefined reference to `XF86VidModeSetGammaRamp'
collect2: error: ld returned 1 exit status
```